### PR TITLE
作成したタスクを編集できるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -23,6 +23,12 @@ class TasksController < ApplicationController
     @task = Task.find(params[:id])
   end
 
+  def update
+    task = Task.find(params[:id])
+    task.update!(task_params)
+    redirect_to task_url, notice: "タスク「#{task.name}」を更新しました。"
+  end
+
   private
 
     def task_params

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,6 +19,10 @@ class TasksController < ApplicationController
     redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
   end
 
+  def edit
+    @task = Task.find(params[:id])
+  end
+
   private
 
     def task_params

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,0 +1,9 @@
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,0 +1,14 @@
+h1 タスクの編集
+
+.nav_justify-content-end
+  = link_to '一覧', tasks_path, class: 'nav-link'
+
+= form_with model: @task, local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'task_name'
+
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
+  = f.submit nil, class: 'btn btn-primary'

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -3,12 +3,4 @@ h1 タスクの編集
 .nav_justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', lacals: { task: @task }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -13,3 +13,5 @@ table.table.table.hover
       tr
         td= link_to task.name, task
         td= task.created_at
+        td
+          = link_to "編集", edit_task_path(task), class: 'btn btn-primary mr-3'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -3,12 +3,4 @@ h1 タスクの新規登録
 .nav_justify-content-end
   = link_to '一覧', tasks_path, class: 'nav-link'
 
-= form_with model: @task, local: true do |f|
-  .form-group
-    = f.label :name
-    = f.text_field :name, class: 'form-control', id: 'task_name'
-
-  .form-group
-    = f.label :description
-    = f.text_area :description, rows: 5, class: 'form-control', id: 'task_description'
-  = f.submit nil, class: 'btn btn-primary'
+= render partial: 'form', locals: { task: @task }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: 'tasks#index'
 
-  resources :tasks, only: [:index, :show, :new, :create]
+  resources :tasks, only: [:index, :show, :new, :create, :edit]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: 'tasks#index'
 
-  resources :tasks, only: [:index, :show, :new, :create, :edit]
+  resources :tasks, only: [:index, :show, :new, :create, :edit, :update]
 end


### PR DESCRIPTION
Taskの`edit`と`update`アクションを作成して、作成したタスクを編集できるようにします。
`new`アクションで使用しているフォームを共通化できるので、まとめました。
