### PR TITLE
タスク詳細画面にはIDでなく名前を表示します

### DIFF
--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -6,7 +6,7 @@ table.table.table-.hover
   tbody
     tr
       th= Task.human_attribute_name(:name)
-      td= @task.id
+      td= @task.name
     tr
       th= Task.human_attribute_name(:description)
       td= simple_format(h(@task.description), {}, sanitize: false, wrapper_tag: "div")


### PR DESCRIPTION
https://github.com/ikaruga777/taskleaf/pull/9 で詳細画面を作ったのですが、`名前`の欄にIDが入ってしまっていたので、タスクの名前を表示するようにします。