### PR TITLE
タスクを削除できるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -29,6 +29,12 @@ class TasksController < ApplicationController
     redirect_to task_url, notice: "タスク「#{task.name}」を更新しました。"
   end
 
+  def destroy
+    task = Task.find(params[:id])
+    task.delete
+    redirect_to tasks_url, notice: "タスク「#{task.name}」を削除しました。"
+  end
+
   private
 
     def task_params

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -15,3 +15,4 @@ table.table.table.hover
         td= task.created_at
         td
           = link_to "編集", edit_task_path(task), class: 'btn btn-primary mr-3'
+          = link_to "削除", task, method: :delete, data: { confirm: "タスク「#{task.name}」を削除しますか?" }, class: 'btn btn-danger'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -16,3 +16,6 @@ table.table.table-.hover
     tr
       th= Task.human_attribute_name(:updated_at)
       td= @task.updated_at
+
+= link_to '編集', edit_task_path, class: 'btn btn-primary mr-3'
+= link_to "削除", @task, method: :delete, data: { confirm: "タスク「#{@task.name}」を削除しますか?" }, class: 'btn btn-danger'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   root to: 'tasks#index'
 
-  resources :tasks, only: [:index, :show, :new, :create, :edit, :update]
+  resources :tasks
 end


### PR DESCRIPTION
タスクを削除するdestroyアクションを実装します。
合わせて、詳細ページと一覧ページにタスクの削除ボタンを作って削除できるようにします。

### 一覧ページ
![image](https://user-images.githubusercontent.com/2727257/56089882-cef8cb80-5ed4-11e9-9c21-383e995bec09.png)
### 詳細ページ
![image](https://user-images.githubusercontent.com/2727257/56089885-e0da6e80-5ed4-11e9-986c-c93ec227372c.png)
